### PR TITLE
Text always null(Russian validator)

### DIFF
--- a/src/main/java/com/softserve/teachua/dto/club/validation/CheckRussianValidator.java
+++ b/src/main/java/com/softserve/teachua/dto/club/validation/CheckRussianValidator.java
@@ -23,7 +23,7 @@ public class CheckRussianValidator implements ConstraintValidator<CheckRussian,S
     @Override
     public boolean isValid(String text, ConstraintValidatorContext constraintValidatorContext) {
 
-        if (text.isEmpty() || text==null){
+        if (text.isEmpty()){
             throw new IncorrectInputException("Text cannot be empty or null");
         }
 


### PR DESCRIPTION
Condition 'text == null' is always 'false' when reached 
That is why throw exception