### PR TITLE
Fix security for frontend

### DIFF
--- a/src/main/java/com/softserve/teachua/config/SecurityConfig.java
+++ b/src/main/java/com/softserve/teachua/config/SecurityConfig.java
@@ -72,7 +72,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authenticationEntryPoint(new RestAuthenticationEntryPoint())
                 .and()
                 .authorizeRequests()
-                .antMatchers("/").permitAll()
                 .antMatchers("/static/**").permitAll()
                 .antMatchers("/manifest.json").permitAll()
                 .antMatchers("/favicon**").permitAll()
@@ -107,8 +106,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 //TODO: only for admin
                 .antMatchers(HttpMethod.GET, "/logs").permitAll()
                 .antMatchers(HttpMethod.DELETE, "/logs").permitAll()
-                .anyRequest()
-                .authenticated()
                 .and()
                 .oauth2Login()
                 .authorizationEndpoint()


### PR DESCRIPTION
Before: 
1) If you go to a non-existent page, get 401.
2) Anyone can go to the page for the administrator.

Now:
1) If you go to a non-existent page, get 404.
2) If the user wants to go to the page for the administrator, the user will get 401. 