### PR TITLE
Fix update user

### DIFF
--- a/src/main/java/com/softserve/teachua/dto/user/UserUpdateProfile.java
+++ b/src/main/java/com/softserve/teachua/dto/user/UserUpdateProfile.java
@@ -28,7 +28,7 @@ public class UserUpdateProfile implements Convertible {
     private String lastName;
 
     @NotBlank
-    @Pattern(regexp = "^[+]*[(]{0,1}[0-9]{1,3}[)]{0,1}[-\\s\\.0-9]{9}$", message = "Phone number must contain 10 numbers and can`t contain other symbols")
+    @Pattern(regexp = "^(\\+380)[0-9]{9}|(380)[0-9]{9}|^0[0-9]{9}$", message = "Phone number must contain 10 numbers and can`t contain other symbols")
 
     private String phone;
 

--- a/src/main/java/com/softserve/teachua/dto/user/UserUpdateProfile.java
+++ b/src/main/java/com/softserve/teachua/dto/user/UserUpdateProfile.java
@@ -28,7 +28,7 @@ public class UserUpdateProfile implements Convertible {
     private String lastName;
 
     @NotBlank
-    @Pattern(regexp = "0[0-9]{9}", message = "Phone number must contain 10 numbers and can`t contain other symbols")
+    @Pattern(regexp = "^[+]*[(]{0,1}[0-9]{1,3}[)]{0,1}[-\\s\\.0-9]{9}$", message = "Phone number must contain 10 numbers and can`t contain other symbols")
 
     private String phone;
 

--- a/src/main/java/com/softserve/teachua/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/softserve/teachua/service/impl/UserServiceImpl.java
@@ -240,12 +240,13 @@ public class UserServiceImpl implements UserService, ArchiveMark<User> {
         if (!userProfile.getEmail().equals(user.getEmail())) {
             throw new IncorrectInputException(EMAIL_UPDATING_ERROR);
         }
+        /*   Admin must be able to appoint someone else as the admin
 
         if (userProfile.getRole().equals(RoleData.ADMIN.getDBRoleName())
                 && !user.getRole().getName().equals(RoleData.ADMIN.getDBRoleName())) {
             throw new IncorrectInputException(ROLE_UPDATING_ERROR);
         }
-
+        */
         User newUser = dtoConverter.convertToEntity(userProfile, user)
                 .withPassword(user.getPassword())
                 .withId(id)


### PR DESCRIPTION
dev

## Code reviewers

- [ ] @JaroslavGarasym 
- [ ] @softservedata 

### Second Level Review

- [ ] @marianben 

## Summary of issue

The user's update needed to be fixed because the admin could not change user role or make him active / inactive

## Summary of change

Here I changed the pattern for phone validation because it worked incorrectly. Validation now supports the following types:
**+38** (phone),  
**38** (phone),  
(phone).
Example phone - 0961234567

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
