### PR TITLE
Updated GitHub actions configurations

### DIFF
--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -40,7 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          mvn --batch-mode --update-snapshots test sonar:sonar \
+          mvn --batch-mode --update-snapshots verify sonar:sonar \
           -Dmaven.test.failure.ignore=true \
           -Dcheckstyle.failOnViolation=false \
           -Dsonar.java.checkstyle.reportPaths=target/checkstyle-result.xml

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -1,4 +1,4 @@
-name: sonar
+name: Sonar
 on:
   push:
     branches:
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    name: Build
+    name: analysis
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -39,4 +39,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify sonar:sonar
+        run: |
+          mvn --batch-mode --update-snapshots test sonar:sonar \
+          -Dmaven.test.failure.ignore=true \
+          -Dcheckstyle.failOnViolation=false \
+          -Dsonar.java.checkstyle.reportPaths=target/checkstyle-result.xml

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,20 +1,17 @@
-name: style
+name: Checkstyle
 on: pull_request
 jobs:
-  run_tests:
+  build:
+    name: validate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 8
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
       - name: Run check style with Maven
-        run: mvn validate
+        run: mvn --batch-mode --update-snapshots validate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,20 +1,17 @@
-name: tests
+name: Tests
 on: pull_request
 jobs:
-  run_tests:
+  build:
+    name: verify
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 8
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
       - name: Run tests with Maven
-        run: mvn -B test --file pom.xml -D"checkstyle.skip"=true
+        run: mvn --batch-mode --update-snapshots verify -Dcheckstyle.skip


### PR DESCRIPTION
Improved GitHub Actions workflow:
- In Test Action, maven phase changed from `test` to `verify` for running integration tests.
- Sonar Action does not fail build if Checkstyle and/or Tests does not pass.
- Checkstyle report sends to Sonarcloud
- Actions based on Java 17 version.
