### PR TITLE
Added PhotoExtension annotation which checks format of the file wheth…

### DIFF
--- a/src/main/java/com/softserve/teachua/dto/task/CreateTask.java
+++ b/src/main/java/com/softserve/teachua/dto/task/CreateTask.java
@@ -8,6 +8,7 @@ import com.softserve.teachua.utils.deserializers.HtmlModifyDeserialize;
 import com.softserve.teachua.utils.deserializers.TrimDeserialize;
 import com.softserve.teachua.utils.validations.CheckForeignLanguage;
 import java.time.LocalDate;
+import com.softserve.teachua.utils.validations.PhotoExtension;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -40,6 +41,7 @@ public class CreateTask implements Convertible {
     private String description;
     @NotBlank
     @Pattern(regexp = "/upload/\\b.+/[^/]+\\.[A-z]+", message = "Incorrect file path. It must be like /upload/*/*.png")
+    @PhotoExtension
     private String picture;
     @NotNull
     @Future(message = "дата має бути в майбутньому")

--- a/src/main/java/com/softserve/teachua/utils/validations/PhotoExtension.java
+++ b/src/main/java/com/softserve/teachua/utils/validations/PhotoExtension.java
@@ -8,7 +8,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Use this annotation to check whether file is a photo of allowed formats
+ * Use this annotation to check whether file is a photo of allowed formats.
  */
 @Target({ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/com/softserve/teachua/utils/validations/PhotoExtension.java
+++ b/src/main/java/com/softserve/teachua/utils/validations/PhotoExtension.java
@@ -1,0 +1,22 @@
+package com.softserve.teachua.utils.validations;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use this annotation to check whether file is a photo of allowed formats
+ */
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PhotoExtensionValidator.class)
+public @interface PhotoExtension {
+    String message() default "Неправильний формат файлу. Дозволені формати: .jpg, .jpeg та .png";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/softserve/teachua/utils/validations/PhotoExtensionValidator.java
+++ b/src/main/java/com/softserve/teachua/utils/validations/PhotoExtensionValidator.java
@@ -1,0 +1,21 @@
+package com.softserve.teachua.utils.validations;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class PhotoExtensionValidator implements ConstraintValidator<PhotoExtension, String> {
+    private static final String[] ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png"};
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        for (String extension : ALLOWED_EXTENSIONS) {
+            if (value.toLowerCase().endsWith(extension)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Added PhotoExtension annotation which checks format of the file whether it is jpg., jpeg., and png. 

Class `PhotoExtensionValidator` and Interface `PhotoExtension` were creted. They both implement annotation `@PhotoExtension` which is used to validate picture extension in `CreateTask.class`
    
## Checklist:

-   [ ] I have added tests with code coverage `>=75%`
-   [x] My code pass Checkstyle rules
-   [x] PR is reviewed manually again (to make sure you have 100% ready code)
-   [ ] All reviewers agreed to merge the PR
