### PR TITLE
Add environmental variables instead of hardcoded credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ workspace.xml
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+#.environmental variables
+.env

--- a/src/test/playwright/constants/general.constants.js
+++ b/src/test/playwright/constants/general.constants.js
@@ -1,7 +1,9 @@
-export const ADMIN_EMAIL = 'admin@gmail.com';
-export const ADMIN_PASSWORD = 'admin';
-export const USER_EMAIL = 'user@gmail.com';
-export const USER_PASSWORD = 'user';
+require('dotenv').config();
+
+export const ADMIN_EMAIL = process.env.ADMIN_EMAIL;
+export const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
+export const USER_EMAIL = process.env.USER_EMAIL;
+export const USER_PASSWORD = process.env.USER_PASSWORD;
 export const USER_ROLES = {
     admin: 'admin',
     user: 'user',


### PR DESCRIPTION
In this pull request, I've replaced the hardcoded credentials with variables from .env, and added the .env file to the .gitignore file.