### PR TITLE
Split challenge manipulation test & refactor

### DIFF
--- a/src/test/playwright/PO/ChallengesPage.js
+++ b/src/test/playwright/PO/ChallengesPage.js
@@ -10,7 +10,7 @@ class ChallengesPage extends BasePage {
         this.openTasksButton = page.locator('a.back-btn button');
         this.addTaskButton = page.locator('a[href="/dev/admin/addTask"]');
         this.allChallengesSequenceNumbers = page.locator(
-            `td.ant-table-cell:nth-child(${CHALLENGES_PAGE.sequenceNumberTableColumn})`
+            `td.ant-table-cell:nth-child(${CHALLENGES_PAGE.sequenceNumberTableColumn}) a`
         );
         this.firstChallenge = page.locator('tr:first-child td.ant-table-cell:first-child');
         this.editChallengeButtons = page.locator('span.table-action').filter({ hasText: CHALLENGES_PAGE.edit });

--- a/src/test/playwright/PO/TasksPage.js
+++ b/src/test/playwright/PO/TasksPage.js
@@ -77,7 +77,7 @@ class TasksPage extends BasePage {
         } else if (await this.isNextPageAvailable()) {
             // If the club is not found on this page, checks if there's a next page and recursively search
             await this.goToNextPage();
-            await this.selectTaskManageOption(challengeSortNumber, option);
+            await this.selectTaskManageOption(taskName, option);
         } else {
             // If the club is not found and there are no more pages, throws an error
             throw new Error("No such task exists");

--- a/src/test/playwright/constants/api.constants.js
+++ b/src/test/playwright/constants/api.constants.js
@@ -55,11 +55,23 @@ export const CREATE_CHALLENGE_REQUEST  = {
     },
 };
 
+export const CREATE_CHALLENGE_REQUEST_2  = {
+    url: "http://localhost:8080/dev/api/challenge",
+    method: "POST",
+    body: {
+        name: "Tasks Testing Challenge",
+        description: "Description for a challenge which purpose is to test tasks functionality. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident.",
+        title: "Test for a task",
+        picture: "/upload/challenges/challenge1.jpg",
+        sortNumber: 54321
+    },
+};
+
 export const CREATE_TASK_REQUEST  = {
     url: "http://localhost:8080/dev/api/challenge",
     method: "POST",
     body: {
-        name: "Super Task Name",
+        name: "First Task Request",
         headerText: "Splendid test Task title. Minimum 40 chars",
         description: "A new TASK test description. Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet.",
         startDate: "2024-12-12",

--- a/src/test/playwright/constants/challengeAndTaskInformation.constants.js
+++ b/src/test/playwright/constants/challengeAndTaskInformation.constants.js
@@ -16,7 +16,7 @@ export const EDITED_CHALLENGE_CORRECT_DETAILS = {
 }
 
 export const NEW_TASK_CORRECT_DETAILS = {
-    startDate: '2023-12-12',
+    startDate: '2024-06-12',
     name: 'Super Task Name',
     title: 'Splendid test Task title. Minimum 40 chars',
     description: 'A new TASK test description. Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet.'

--- a/src/test/playwright/services/ApiService.js
+++ b/src/test/playwright/services/ApiService.js
@@ -1,7 +1,7 @@
 
 import { expect} from "@playwright/test";
 import { ADMIN_EMAIL, ADMIN_PASSWORD, USER_EMAIL, USER_PASSWORD } from "../constants/general.constants";
-import {SIGN_IN_URL, CREATE_CLUB_REQUEST , USERS_CLUBS, CREATE_CHALLENGE_REQUEST, CREATE_TASK_REQUEST, GET_CHALLENGES_REQUEST, GET_TASK_REQUEST} from "../constants/api.constants";
+import {SIGN_IN_URL, CREATE_CLUB_REQUEST , USERS_CLUBS, CREATE_CHALLENGE_REQUEST_2, CREATE_TASK_REQUEST, GET_CHALLENGES_REQUEST, GET_TASK_REQUEST} from "../constants/api.constants";
 
 
 class ApiService {
@@ -164,7 +164,7 @@ class ApiService {
             return;
         }
         const challenges = await this.getAllChallenges();
-        const challenge = challenges.find((c) => c.sortNumber === parseInt(CREATE_CHALLENGE_REQUEST.body.sortNumber));
+        const challenge = challenges.find((c) => c.sortNumber === parseInt(CREATE_CHALLENGE_REQUEST_2.body.sortNumber));
         CREATE_TASK_REQUEST.body.challengeId = challenge.id;
         if (challenge) {
             const response = await fetch(`http://localhost:8080/dev/api/challenge/${challenge.id}/task`, {

--- a/src/test/playwright/tests/challengesManipulation-test.spec.js
+++ b/src/test/playwright/tests/challengesManipulation-test.spec.js
@@ -1,201 +1,116 @@
-import { test} from "@playwright/test";
+import { test, chromium } from "@playwright/test";
 import ApiService from "../services/ApiService";
 import ChallengesPage from "../PO/ChallengesPage";
-import ChallengeInfoPage from "../PO/ChallengeInfoPage";
-import TasksPage from "../PO/TasksPage";
 import AddChallengePage from "../PO/AddChallengePage";
-import AddTaskPage from "../PO/AddTaskPage";
-import {CREATE_CHALLENGE_REQUEST, CREATE_TASK_REQUEST, CREATE_TASK_REQUEST_2, CREATE_TASK_REQUEST_3, CREATE_TASK_REQUEST_4, TASKS_ADMIN_URL} from "../constants/api.constants";
-import {NEW_CHALLENGE_CORRECT_DETAILS, EDITED_CHALLENGE_CORRECT_DETAILS, NEW_TASK_CORRECT_DETAILS, EDITED_TASK_CORRECT_DETAILS} from "../constants/challengeAndTaskInformation.constants";
-import { USER_ROLES } from "../constants/general.constants"
+import ChallengeInfoPage from "../PO/ChallengeInfoPage"
+import {
+    CREATE_CHALLENGE_REQUEST,
+} from "../constants/api.constants";
+import {
+    NEW_CHALLENGE_CORRECT_DETAILS,
+    EDITED_CHALLENGE_CORRECT_DETAILS,
+} from "../constants/challengeAndTaskInformation.constants";
+import { USER_ROLES } from "../constants/general.constants";
 
-let apiService, challengesPage, challengeInfoPage,tasksPage, addChallengePage, addTaskPage;
+let page, apiService, challengesPage, addChallengePage, challengeInfoPage;
 
-    test.beforeEach(async({page})=>{
-        apiService = new ApiService(page);
-        challengesPage = new ChallengesPage(page);
-        await apiService.apiLoginAs(USER_ROLES.admin);
-    })
+test.beforeAll(async () => {
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    page = await context.newPage();
+    apiService = new ApiService(page);
+    challengeInfoPage = new ChallengeInfoPage(page);
+    challengesPage = new ChallengesPage(page);
+    addChallengePage = new AddChallengePage(page);
 
-    test("Verify that a new challenge can be successfully created", async ({ page }) => {
-        await challengesPage.gotoChallengesPage();
-        addChallengePage = new AddChallengePage(page);
-        await apiService.deleteChallengeBySequenceNumber(NEW_CHALLENGE_CORRECT_DETAILS.sequenceNumber
-);
-        await challengesPage.openAddChallengePage();
-        await addChallengePage.fillInputField(addChallengePage.challengeSequenceNumberField, NEW_CHALLENGE_CORRECT_DETAILS.sequenceNumber
-)
-        await addChallengePage.fillInputField(addChallengePage.challengeNameField, NEW_CHALLENGE_CORRECT_DETAILS.name)
-        await addChallengePage.fillInputField(addChallengePage.challengeTitleField, NEW_CHALLENGE_CORRECT_DETAILS.title)
-        await addChallengePage.fillInputField(addChallengePage.challengeDescriptionField, NEW_CHALLENGE_CORRECT_DETAILS.description)
-        await addChallengePage.uploadChallengePhoto();
-        await addChallengePage.confirmChallengeCreation();
+    await apiService.apiLoginAs(USER_ROLES.admin);
+    try {
+        await apiService.deleteChallengeBySequenceNumber(NEW_CHALLENGE_CORRECT_DETAILS.sequenceNumber);
+    } catch (err) {
+        console.log(err);
+    }
+});
 
-        await addChallengePage.verifyElementVisibility(addChallengePage.challengeAddedSuccessMessage);
-        await addChallengePage.openChallengesPage();
-        await addChallengePage.verifyElementExistance(challengesPage.allChallengesSequenceNumbers, NEW_CHALLENGE_CORRECT_DETAILS.sequenceNumber
-)
+test.beforeEach(async () => {
+    await apiService.createNewChallenge(CREATE_CHALLENGE_REQUEST);
+    await challengesPage.gotoChallengesPage();
+});
 
-    });
+test("Verify that a new challenge can be successfully created", async () => {
+    await challengesPage.openAddChallengePage();
+    await addChallengePage.fillInputField(
+        addChallengePage.challengeSequenceNumberField,
+        NEW_CHALLENGE_CORRECT_DETAILS.sequenceNumber
+    );
+    await addChallengePage.fillInputField(addChallengePage.challengeNameField, NEW_CHALLENGE_CORRECT_DETAILS.name);
+    await addChallengePage.fillInputField(addChallengePage.challengeTitleField, NEW_CHALLENGE_CORRECT_DETAILS.title);
+    await addChallengePage.fillInputField(
+        addChallengePage.challengeDescriptionField,
+        NEW_CHALLENGE_CORRECT_DETAILS.description
+    );
+    await addChallengePage.uploadChallengePhoto();
+    await addChallengePage.confirmChallengeCreation();
 
+    await addChallengePage.verifyElementVisibility(addChallengePage.challengeAddedSuccessMessage);
+    await addChallengePage.openChallengesPage();
+    await addChallengePage.verifyElementExistance(
+        challengesPage.allChallengesSequenceNumbers,
+        NEW_CHALLENGE_CORRECT_DETAILS.sequenceNumber
+    );
+});
 
-    test("Verify that a new task can be successfully added to an existing challenge", async ({ page }) => {
-        tasksPage = new TasksPage(page);
-        addTaskPage = new AddTaskPage(page);
-        challengeInfoPage = new ChallengeInfoPage(page);
-        await apiService.deleteTaskByName(NEW_TASK_CORRECT_DETAILS.name);
+test("Verify that a challenge can be succesfully deleted", async () => {
+    await challengesPage.deleteChallenge(CREATE_CHALLENGE_REQUEST.body.sortNumber);
+    await challengesPage.verifyElementVisibility(challengesPage.actionSuccessMessage);
+    await challengesPage.verifyElementExistance(
+        challengesPage.allChallengesSequenceNumbers,
+        CREATE_CHALLENGE_REQUEST.body.sortNumber,
+        false
+    );
+});
 
-        await apiService.createNewChallenge(CREATE_CHALLENGE_REQUEST);
-        await tasksPage.gotoTasksPage();
-        await tasksPage.openAddTaskPage();
+test("Verify that an existing challenge can be edited on the challenges list page", async () => {
+    await apiService.deleteChallengeBySequenceNumber(EDITED_CHALLENGE_CORRECT_DETAILS.sequenceNumber);
+    await challengesPage.gotoChallengesPage();
+    await challengesPage.turnOnEditChallenge(CREATE_CHALLENGE_REQUEST.body.sortNumber);
+    await challengesPage.fillInputField(
+        challengesPage.challengeSequenceNumberField,
+        EDITED_CHALLENGE_CORRECT_DETAILS.sequenceNumber
+    );
+    await challengesPage.fillInputField(challengesPage.challengeNameField, EDITED_CHALLENGE_CORRECT_DETAILS.name);
+    await challengesPage.fillInputField(challengesPage.challengeTitleField, EDITED_CHALLENGE_CORRECT_DETAILS.title);
+    await challengesPage.confirmEditChallenge();
+    await challengesPage.verifyElementExistance(
+        challengesPage.allChallengesSequenceNumbers,
+        EDITED_CHALLENGE_CORRECT_DETAILS.sequenceNumber,
+        true
+    );
+});
 
-        await addTaskPage.selectDate(NEW_TASK_CORRECT_DETAILS.startDate);
-        await addTaskPage.uploadTaskPhoto();
-        await addTaskPage.fillInputField(addTaskPage.taskNameField, NEW_TASK_CORRECT_DETAILS.name);
-        await addTaskPage.fillInputField(addTaskPage.taskTitleField, NEW_TASK_CORRECT_DETAILS.title);
-        await addTaskPage.fillInputField(addTaskPage.taskDescriptionField, NEW_TASK_CORRECT_DETAILS.description);
-        await addTaskPage.selectChallenge(CREATE_CHALLENGE_REQUEST.body.name);
+test("Verify that an existing challenge can be edited", async () => {
+    await apiService.deleteChallengeBySequenceNumber(EDITED_CHALLENGE_CORRECT_DETAILS.sequenceNumber);
+    await challengesPage.gotoChallengesPage();
+    await challengesPage.openChallengeInfoPage(CREATE_CHALLENGE_REQUEST.body.sortNumber);
+    await addChallengePage.fillInputField(
+        addChallengePage.challengeSequenceNumberField,
+        EDITED_CHALLENGE_CORRECT_DETAILS.sequenceNumber
+    );
+    await addChallengePage.fillInputField(addChallengePage.challengeNameField, EDITED_CHALLENGE_CORRECT_DETAILS.name);
+    await addChallengePage.fillInputField(addChallengePage.challengeTitleField, EDITED_CHALLENGE_CORRECT_DETAILS.title);
+    await addChallengePage.fillInputField(
+        addChallengePage.challengeDescriptionField,
+        EDITED_CHALLENGE_CORRECT_DETAILS.description
+    );
+    await addChallengePage.confirmChallengeCreation();
+    await addChallengePage.verifyElementVisibility(addChallengePage.challengeAddedSuccessMessage);
+    await challengesPage.gotoChallengesPage();
+    await challengesPage.verifyElementExistance(
+        challengesPage.allChallengesSequenceNumbers,
+        EDITED_CHALLENGE_CORRECT_DETAILS.sequenceNumber,
+        true
+    );
+});
 
-        await addTaskPage.confirmTaskCreation();
-
-        await addTaskPage.verifyElementVisibility(addTaskPage.taskAddedSuccessMessage);
-
-        await tasksPage.gotoTasksPage();
-        await tasksPage.verifyElementExistance(tasksPage.allTasksNames, NEW_TASK_CORRECT_DETAILS.name);
-
-        await tasksPage.openChallengesPage();
-        await challengesPage.openChallengeInfoPage(CREATE_CHALLENGE_REQUEST.body.sortNumber);
-        await challengeInfoPage.verifyElementExistance(
-            challengeInfoPage.tasksTableCells,
-            NEW_TASK_CORRECT_DETAILS.name
-        );
-    });
-
-
-    test("Verify that a challenge can be succesfully deleted", async ({ page }) => {
-        await apiService.createNewChallenge(CREATE_CHALLENGE_REQUEST);
-        await challengesPage.gotoChallengesPage();
-        await challengesPage.deleteChallenge(CREATE_CHALLENGE_REQUEST.body.sortNumber);
-        await challengesPage.verifyElementVisibility(challengesPage.actionSuccessMessage);
-        await challengesPage.verifyElementExistance(
-            challengesPage.allChallengesSequenceNumbers,
-            CREATE_CHALLENGE_REQUEST.body.sortNumber,
-            false
-        );
-    });
-
-    test("Verify that an existing challenge can be edited on the challenges list page", async ({ page }) => {
-        await apiService.createNewChallenge(CREATE_CHALLENGE_REQUEST);
-        await apiService.deleteChallengeBySequenceNumber(EDITED_CHALLENGE_CORRECT_DETAILS.sequenceNumber);
-        await challengesPage.gotoChallengesPage();
-        await challengesPage.turnOnEditChallenge(CREATE_CHALLENGE_REQUEST.body.sortNumber);
-        await challengesPage.fillInputField(
-            challengesPage.challengeSequenceNumberField,
-            EDITED_CHALLENGE_CORRECT_DETAILS.sequenceNumber
-        );
-        await challengesPage.fillInputField(challengesPage.challengeNameField, EDITED_CHALLENGE_CORRECT_DETAILS.name);
-        await challengesPage.fillInputField(challengesPage.challengeTitleField, EDITED_CHALLENGE_CORRECT_DETAILS.title);
-        await challengesPage.confirmEditChallenge();
-        await challengesPage.verifyElementExistance(
-            challengesPage.allChallengesSequenceNumbers,
-            EDITED_CHALLENGE_CORRECT_DETAILS.sequenceNumber,
-            true
-        );
-    });
-
-    test("Verify that an existing challenge can be edited", async ({ page }) => {
-        addChallengePage = new AddChallengePage(page);
-        await apiService.deleteChallengeBySequenceNumber(EDITED_CHALLENGE_CORRECT_DETAILS.sequenceNumber
-);
-        await apiService.createNewChallenge(CREATE_CHALLENGE_REQUEST);
-        await challengesPage.gotoChallengesPage();
-        await challengesPage.openChallengeInfoPage(CREATE_CHALLENGE_REQUEST.body.sortNumber);
-        await addChallengePage.fillInputField(addChallengePage.challengeSequenceNumberField, EDITED_CHALLENGE_CORRECT_DETAILS.sequenceNumber
-)
-        await addChallengePage.fillInputField(addChallengePage.challengeNameField, EDITED_CHALLENGE_CORRECT_DETAILS.name)
-        await addChallengePage.fillInputField(addChallengePage.challengeTitleField, EDITED_CHALLENGE_CORRECT_DETAILS.title)
-        await addChallengePage.fillInputField(addChallengePage.challengeDescriptionField, EDITED_CHALLENGE_CORRECT_DETAILS.description)
-        await addChallengePage.confirmChallengeCreation();
-        await addChallengePage.verifyElementVisibility(addChallengePage.challengeAddedSuccessMessage);
-        await challengesPage.gotoChallengesPage();
-        await challengesPage.verifyElementExistance(challengesPage.allChallengesSequenceNumbers, EDITED_CHALLENGE_CORRECT_DETAILS.sequenceNumber
-, true);
-    });
-    
-    test("Verify that a task can be succesfully deleted", async({page})=>{
-        tasksPage = new TasksPage(page);
-        await apiService.createNewChallenge(CREATE_CHALLENGE_REQUEST);
-        await apiService.createNewTask(CREATE_TASK_REQUEST);
-        await tasksPage.gotoTasksPage();
-        await tasksPage.deleteTask(CREATE_TASK_REQUEST.body.name);
-        await tasksPage.verifyElementVisibility(tasksPage.actionSuccessMessage);
-        
-        // Verification below won't work if there a couple of tasks with the same name
-        await tasksPage.verifyElementExistance(
-            tasksPage.allTasksNames,
-            CREATE_TASK_REQUEST.body.name, false
-        );
-    })
-
-    test("Verify that an existing task can be edited on the tasks list page", async({page})=>{
-        tasksPage = new TasksPage(page);
-        await apiService.createNewChallenge(CREATE_CHALLENGE_REQUEST);
-        await apiService.deleteTaskByName(EDITED_TASK_CORRECT_DETAILS.name)
-        await apiService.createNewTask(CREATE_TASK_REQUEST);
-        await tasksPage.gotoTasksPage();
-        await tasksPage.turnOnEditTask(CREATE_TASK_REQUEST.body.name);
-        await tasksPage.fillInputField(tasksPage.taskNameField, EDITED_TASK_CORRECT_DETAILS.name)
-        await tasksPage.confirmEditTask();
-        await tasksPage.verifyElementExistance(
-            challengesPage.allChallengesSequenceNumbers,
-            EDITED_TASK_CORRECT_DETAILS.name,
-            true
-        );
-     })
-
-
-    test("Verify that an existing task can be edited", async ({ page }) => {
-        tasksPage = new TasksPage(page);
-        addTaskPage = new AddTaskPage(page);
-        await apiService.deleteTaskByName(EDITED_TASK_CORRECT_DETAILS.name);
-        await apiService.createNewChallenge(CREATE_CHALLENGE_REQUEST);
-        await apiService.createNewTask(CREATE_TASK_REQUEST);
-        await tasksPage.gotoTasksPage();
-        await tasksPage.openTaskInfoPage(CREATE_TASK_REQUEST.body.name);
-        await addTaskPage.fillInputField(addTaskPage.taskNameField, EDITED_TASK_CORRECT_DETAILS.name);
-        await addTaskPage.fillInputField(addTaskPage.taskTitleField, EDITED_TASK_CORRECT_DETAILS.title);
-        await addTaskPage.fillInputField(addTaskPage.taskDescriptionField, EDITED_TASK_CORRECT_DETAILS.description);
-        await addTaskPage.confirmTaskCreation();
-        await addTaskPage.verifyElementVisibility(addTaskPage.taskAddedSuccessMessage);
-        await tasksPage.gotoTasksPage();
-        await tasksPage.verifyElementExistance(tasksPage.allTasksNames, EDITED_TASK_CORRECT_DETAILS.name, true);
-    });
-
-
-    test("Verify that the user can navigate through challenge's existing tasks", async({page})=>{
-        tasksPage = new TasksPage(page);
-        challengeInfoPage = new ChallengeInfoPage(page);
-        await apiService.deleteTaskByName(CREATE_TASK_REQUEST.body.name);
-        await apiService.deleteTaskByName(CREATE_TASK_REQUEST_2.body.name);
-        await apiService.deleteTaskByName(CREATE_TASK_REQUEST_3.body.name);
-        await apiService.deleteTaskByName(CREATE_TASK_REQUEST_4.body.name);
-
-        await apiService.createNewChallenge(CREATE_CHALLENGE_REQUEST);
-        await apiService.createNewTask(CREATE_TASK_REQUEST);
-        await apiService.changeTaskDateToToday(CREATE_TASK_REQUEST.body.name);
-        await apiService.createNewTask(CREATE_TASK_REQUEST_2);
-        await apiService.changeTaskDateToToday(CREATE_TASK_REQUEST_2.body.name);
-        await apiService.createNewTask(CREATE_TASK_REQUEST_3);
-        await apiService.changeTaskDateToToday(CREATE_TASK_REQUEST_3.body.name);
-        await apiService.createNewTask(CREATE_TASK_REQUEST_4);
-        await apiService.changeTaskDateToToday(CREATE_TASK_REQUEST_4.body.name);
-        await challengesPage.gotoChallengesPage();
-        await challengesPage.openChallengeInfoPage(CREATE_CHALLENGE_REQUEST.body.sortNumber);
-        await challengeInfoPage.openViewChallenge();
-        await challengeInfoPage.verifyTaskOnChallengeView(CREATE_TASK_REQUEST_4.body.name);
-    })
-
-
-    test.afterEach(async({page})=>{
-        await page.close();
-    })
+test.afterAll(async () => {
+    await page.close();
+});

--- a/src/test/playwright/tests/tasksManipulation-test.spec.js
+++ b/src/test/playwright/tests/tasksManipulation-test.spec.js
@@ -1,0 +1,114 @@
+import { test, chromium } from "@playwright/test";
+import ApiService from "../services/ApiService";
+import ChallengeInfoPage from "../PO/ChallengeInfoPage";
+import TasksPage from "../PO/TasksPage";
+import AddTaskPage from "../PO/AddTaskPage";
+import ChallengesPage from "../PO/ChallengesPage";
+import {
+    CREATE_CHALLENGE_REQUEST_2,
+    CREATE_TASK_REQUEST,
+    CREATE_TASK_REQUEST_2,
+    CREATE_TASK_REQUEST_3,
+    CREATE_TASK_REQUEST_4,
+} from "../constants/api.constants";
+import {
+    NEW_TASK_CORRECT_DETAILS,
+    EDITED_TASK_CORRECT_DETAILS,
+} from "../constants/challengeAndTaskInformation.constants";
+import { USER_ROLES } from "../constants/general.constants";
+
+let page, apiService, challengesPage, challengeInfoPage, tasksPage, addTaskPage;
+
+test.beforeAll(async () => {
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    page = await context.newPage();
+    apiService = new ApiService(page);
+    tasksPage = new TasksPage(page);
+    addTaskPage = new AddTaskPage(page);
+    challengeInfoPage = new ChallengeInfoPage(page);
+    challengesPage = new ChallengesPage(page);
+
+    await apiService.apiLoginAs(USER_ROLES.admin);
+    await apiService.createNewChallenge(CREATE_CHALLENGE_REQUEST_2);
+});
+
+test.beforeEach(async () => {
+    await apiService.createNewTask(CREATE_TASK_REQUEST);
+    await tasksPage.gotoTasksPage();
+});
+
+test("Verify that a new task can be successfully added to an existing challenge", async () => {
+    await apiService.deleteTaskByName(NEW_TASK_CORRECT_DETAILS.name);
+    await tasksPage.openAddTaskPage();
+    await addTaskPage.selectDate(NEW_TASK_CORRECT_DETAILS.startDate);
+    await addTaskPage.uploadTaskPhoto();
+    await addTaskPage.fillInputField(addTaskPage.taskNameField, NEW_TASK_CORRECT_DETAILS.name);
+    await addTaskPage.fillInputField(addTaskPage.taskTitleField, NEW_TASK_CORRECT_DETAILS.title);
+    await addTaskPage.fillInputField(addTaskPage.taskDescriptionField, NEW_TASK_CORRECT_DETAILS.description);
+    await addTaskPage.selectChallenge(CREATE_CHALLENGE_REQUEST_2.body.name);
+    await addTaskPage.confirmTaskCreation();
+
+    await addTaskPage.verifyElementVisibility(addTaskPage.taskAddedSuccessMessage);
+
+    await tasksPage.gotoTasksPage();
+    await tasksPage.verifyElementExistance(tasksPage.allTasksNames, NEW_TASK_CORRECT_DETAILS.name);
+
+    await tasksPage.openChallengesPage();
+    await challengesPage.openChallengeInfoPage(CREATE_CHALLENGE_REQUEST_2.body.sortNumber);
+    await challengeInfoPage.verifyElementExistance(challengeInfoPage.tasksTableCells, NEW_TASK_CORRECT_DETAILS.name);
+});
+
+test("Verify that a task can be succesfully deleted", async () => {
+    await tasksPage.deleteTask(CREATE_TASK_REQUEST.body.name);
+    await tasksPage.verifyElementVisibility(tasksPage.actionSuccessMessage);
+
+    // Verification below won't work if there a couple of tasks with the same name
+    await tasksPage.verifyElementExistance(tasksPage.allTasksNames, CREATE_TASK_REQUEST.body.name, false);
+});
+
+test("Verify that an existing task can be edited on the tasks list page", async () => {
+    await apiService.deleteTaskByName(EDITED_TASK_CORRECT_DETAILS.name);
+    await tasksPage.turnOnEditTask(CREATE_TASK_REQUEST.body.name);
+    await tasksPage.fillInputField(tasksPage.taskNameField, EDITED_TASK_CORRECT_DETAILS.name);
+    await tasksPage.confirmEditTask();
+    await tasksPage.verifyElementExistance(
+        challengesPage.allChallengesSequenceNumbers,
+        EDITED_TASK_CORRECT_DETAILS.name,
+        true
+    );
+});
+
+test("Verify that an existing task can be edited", async () => {
+    await apiService.deleteTaskByName(EDITED_TASK_CORRECT_DETAILS.name);
+    await tasksPage.openTaskInfoPage(CREATE_TASK_REQUEST.body.name);
+    await addTaskPage.fillInputField(addTaskPage.taskNameField, EDITED_TASK_CORRECT_DETAILS.name);
+    await addTaskPage.fillInputField(addTaskPage.taskTitleField, EDITED_TASK_CORRECT_DETAILS.title);
+    await addTaskPage.fillInputField(addTaskPage.taskDescriptionField, EDITED_TASK_CORRECT_DETAILS.description);
+    await addTaskPage.confirmTaskCreation();
+    await addTaskPage.verifyElementVisibility(addTaskPage.taskAddedSuccessMessage);
+    await tasksPage.gotoTasksPage();
+    await tasksPage.verifyElementExistance(tasksPage.allTasksNames, EDITED_TASK_CORRECT_DETAILS.name, true);
+});
+
+test("Verify that the user can navigate through challenge's existing tasks", async () => {
+    await apiService.deleteTaskByName(CREATE_TASK_REQUEST_2.body.name);
+    await apiService.deleteTaskByName(CREATE_TASK_REQUEST_3.body.name);
+    await apiService.deleteTaskByName(CREATE_TASK_REQUEST_4.body.name);
+
+    await apiService.changeTaskDateToToday(CREATE_TASK_REQUEST.body.name);
+    await apiService.createNewTask(CREATE_TASK_REQUEST_2);
+    await apiService.changeTaskDateToToday(CREATE_TASK_REQUEST_2.body.name);
+    await apiService.createNewTask(CREATE_TASK_REQUEST_3);
+    await apiService.changeTaskDateToToday(CREATE_TASK_REQUEST_3.body.name);
+    await apiService.createNewTask(CREATE_TASK_REQUEST_4);
+    await apiService.changeTaskDateToToday(CREATE_TASK_REQUEST_4.body.name);
+    await challengesPage.gotoChallengesPage();
+    await challengesPage.openChallengeInfoPage(CREATE_CHALLENGE_REQUEST_2.body.sortNumber);
+    await challengeInfoPage.openViewChallenge();
+    await challengeInfoPage.verifyTaskOnChallengeView(CREATE_TASK_REQUEST_4.body.name);
+});
+
+test.afterAll(async () => {
+    await page.close();
+});


### PR DESCRIPTION
In this pull request, I've made the following improvements:

- Split the challengeManipulation-test.spec into two test.spec files to enhance maintenance, readability, and execution speed.
- Refactored resulting test.spec files (tasksManipulation-test.spec.js, challengesManipulation-test.spec.js) namely:
Improved beforeEach/All hook logic.
Introduced an additional challenge instance in the .constants file to make both tests independent of each other.

- Fixed a locator in ChallengesPage.js.
- Fixed a method in TasksPage.js.