### PR TITLE
Refactor addClub test

### DIFF
--- a/src/test/playwright/constants/api.constants.js
+++ b/src/test/playwright/constants/api.constants.js
@@ -16,7 +16,7 @@ export const CREATE_CLUB_REQUEST  = {
     method: "POST",
     body: {
         categoriesName: ["Акторська майстерність, театр", "Центр розвитку", "Програмування, робототехніка, STEM"],
-        name: "Test Automation club new",
+        name: "Test Request Club",
         ageFrom: 10,
         ageTo: 18,
         description:
@@ -24,7 +24,39 @@ export const CREATE_CLUB_REQUEST  = {
         userId: "1",
         locations: [
             {
-                name: "Automation City",
+                name: "Test Request Location",
+                cityName: "Дніпро",
+                districtName: "Амур-Нижньодніпровський",
+                stationName: "Метробудівників",
+                address: "Volodymyra Velykoho str.",
+                coordinates: "49.790387, 24.028195",
+                phone: "0671834956",
+                key: 0.112830686973181,
+            },
+        ],
+        urlLogo: "/upload/club/logos/clubLogo.jpg",
+        urlBackground: "/upload/club/backgrounds/cover.png",
+        urlGallery: ["/upload/club/galleries/galery.jpg"],
+        contacts:
+            '{"1"::"1236547891","2"::"someFacebook","3"::"someWhatsUp","4"::"testEmail@gmail.com","6"::"testWebPage.com"}',
+        centerId: 1,
+    },
+};
+
+export const CREATE_CLUB_REQUEST_2  = {
+    url: "http://localhost:8080/dev/api/club",
+    method: "POST",
+    body: {
+        categoriesName: ["Акторська майстерність, театр", "Центр розвитку", "Програмування, робототехніка, STEM"],
+        name: "Test Request Second",
+        ageFrom: 10,
+        ageTo: 18,
+        description:
+            '{"blocks":[{"key":"brl63","text":"This is a test description for a new club. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}',
+        userId: "1",
+        locations: [
+            {
+                name: "Test Request Location 2",
                 cityName: "Дніпро",
                 districtName: "Амур-Нижньодніпровський",
                 stationName: "Метробудівників",

--- a/src/test/playwright/services/ApiService.js
+++ b/src/test/playwright/services/ApiService.js
@@ -1,7 +1,7 @@
 
 import { expect} from "@playwright/test";
 import { ADMIN_EMAIL, ADMIN_PASSWORD, USER_EMAIL, USER_PASSWORD } from "../constants/general.constants";
-import {SIGN_IN_URL, CREATE_CLUB_REQUEST , USERS_CLUBS, CREATE_CHALLENGE_REQUEST, CREATE_TASK_REQUEST, GET_CHALLENGES_REQUEST, GET_TASK_REQUEST} from "../constants/api.constants";
+import {SIGN_IN_URL, USERS_CLUBS, CREATE_CHALLENGE_REQUEST, GET_CHALLENGES_REQUEST, GET_TASK_REQUEST} from "../constants/api.constants";
 
 
 class ApiService {
@@ -59,7 +59,7 @@ class ApiService {
         return responseJson.totalPages;
     }
 
-    async createNewClub() {
+    async createNewClub(CREATE_CLUB_REQUEST) {
         const response = await fetch(CREATE_CLUB_REQUEST.url, {
             method: CREATE_CLUB_REQUEST.method,
             body: JSON.stringify(CREATE_CLUB_REQUEST.body),

--- a/src/test/playwright/tests/addClub-test.spec.js
+++ b/src/test/playwright/tests/addClub-test.spec.js
@@ -1,277 +1,393 @@
-import {test} from "@playwright/test";
+import { test, chromium } from "@playwright/test";
 import ApiService from "../services/ApiService";
 import AddClubPage from "../PO/AddClubPage";
 import HomePage from "../PO/HomePage";
 import UserPage from "../PO/UserPage";
 import ClubInfoPage from "../PO/ClubInfoPage";
-import {CLUB_CATEGORIES, NEW_LOCATION_CORRECT_DETAILS, NEW_CLUB_CORRECT_CONTACT_DETAILS, NEW_CLUB_INCORRECT_CONTACT_DETAILS, NEW_CLUB_CORRECT_DETAILS, NEW_CLUB_INCORRECT_DETAILS, NEW_LOCATION_INCORRECT_DETAILS} from "../constants/clubInformation.constants";
-import {ADD_CLUB_VALIDATION_ERROR_MESSAGE,ADD_LOCATION_VALIDATION_ERROR_MESSAGE, SUCCESS_CLUB_CREATION_MESSAGE} from "../constants/messages.constants";
+import { USER_ROLES } from "../constants/general.constants"
+import {
+    CLUB_CATEGORIES,
+    NEW_LOCATION_CORRECT_DETAILS,
+    NEW_CLUB_CORRECT_CONTACT_DETAILS,
+    NEW_CLUB_INCORRECT_CONTACT_DETAILS,
+    NEW_CLUB_CORRECT_DETAILS,
+    NEW_CLUB_INCORRECT_DETAILS,
+    NEW_LOCATION_INCORRECT_DETAILS,
+} from "../constants/clubInformation.constants";
+import {
+    ADD_CLUB_VALIDATION_ERROR_MESSAGE,
+    ADD_LOCATION_VALIDATION_ERROR_MESSAGE,
+    SUCCESS_CLUB_CREATION_MESSAGE,
+} from "../constants/messages.constants";
+import { CREATE_CLUB_REQUEST } from "../constants/api.constants"
 
-let apiService, addClubPage, homePage, userPage, clubInfoPage;
+let page, apiService, addClubPage, homePage, userPage, clubInfoPage;
 
-    test.beforeEach(async({page})=>{
-        apiService = new ApiService(page);
-        addClubPage = new AddClubPage(page);
-        homePage = new HomePage(page);
+test.describe.configure({
+    mode: "parallel"
+})
 
-        await apiService.apiLoginAs('admin');
-        await homePage.openAddClubPage();
-    })
+test.beforeAll(async () => {
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    page = await context.newPage();
+    apiService = new ApiService(page);
+    addClubPage = new AddClubPage(page);
+    homePage = new HomePage(page);
+    clubInfoPage = new ClubInfoPage(page);
+    userPage = new UserPage(page);
 
-    test("Verify that a new club can be succesfully added", async ({ page }) => {
-        userPage = new UserPage(page);
-        // Remove the club with the test club_title if it exists
-        try {
-            await apiService.deleteClubByTitle(NEW_CLUB_CORRECT_DETAILS.clubTitle);
-        } catch (e) {
-            console.error(e);
-        }
-        
-        await addClubPage.fillInputField(addClubPage.clubNameField, NEW_CLUB_CORRECT_DETAILS.clubTitle);
-        await addClubPage.toggleStatedCheckboxes(
-            CLUB_CATEGORIES.acting,
-            CLUB_CATEGORIES.developmentCenter,
-            CLUB_CATEGORIES.programming
-        );
-        await addClubPage.setAcceptableChildAge(NEW_CLUB_CORRECT_DETAILS.clubEnterAge, NEW_CLUB_CORRECT_DETAILS.clubClosingAge);
-        await addClubPage.selectRelatedCenter(NEW_CLUB_CORRECT_DETAILS.clubRelatedCenter);
-        await addClubPage.proceedToNextStep();
+    await apiService.apiLoginAs(USER_ROLES.admin);
+});
 
+test.beforeEach(async () => {
+    await homePage.openAddClubPage();
+});
 
-        await addClubPage.openAddLocationWindow();
-        await addClubPage.fillInputField(addClubPage.locationNameField, NEW_LOCATION_CORRECT_DETAILS.locationName)
-        await addClubPage.selectLocationCity(NEW_LOCATION_CORRECT_DETAILS.locationCity);
-        await addClubPage.selectLocationDistrict(NEW_LOCATION_CORRECT_DETAILS.locationDistrict);
-        await addClubPage.selectLocationStation(NEW_LOCATION_CORRECT_DETAILS.locationStation);
-        await addClubPage.fillInputField(addClubPage.locationAddressField, NEW_LOCATION_CORRECT_DETAILS.locationAddress)
-        await addClubPage.fillInputField(addClubPage.locationCoordinatesField, NEW_LOCATION_CORRECT_DETAILS.locationCoordinates)
-        await addClubPage.fillInputField(addClubPage.locationPhoneNumberField, NEW_LOCATION_CORRECT_DETAILS.locationPhone);
-        await addClubPage.confirmLocationAddition();
+test("Verify that a new club can be succesfully added", async () => {
+    // Remove the club with the test club_title if it exists
+    await apiService.deleteClubByTitle(NEW_CLUB_CORRECT_DETAILS.clubTitle);
+    await addClubPage.fillInputField(addClubPage.clubNameField, NEW_CLUB_CORRECT_DETAILS.clubTitle);
+    await addClubPage.toggleStatedCheckboxes(
+        CLUB_CATEGORIES.acting,
+        CLUB_CATEGORIES.developmentCenter,
+        CLUB_CATEGORIES.programming
+    );
+    await addClubPage.setAcceptableChildAge(
+        NEW_CLUB_CORRECT_DETAILS.clubEnterAge,
+        NEW_CLUB_CORRECT_DETAILS.clubClosingAge
+    );
+    await addClubPage.selectRelatedCenter(NEW_CLUB_CORRECT_DETAILS.clubRelatedCenter);
+    await addClubPage.proceedToNextStep();
 
-        await addClubPage.verifyLocationPresence(NEW_LOCATION_CORRECT_DETAILS.locationName);
-        
-        await addClubPage.fillInputField(addClubPage.clubPhoneNumberField, NEW_CLUB_CORRECT_CONTACT_DETAILS.phoneNumber);
-        await addClubPage.fillInputField(addClubPage.clubFacebookField, NEW_CLUB_CORRECT_CONTACT_DETAILS.facebook);
-        await addClubPage.fillInputField(addClubPage.clubEmailField, NEW_CLUB_CORRECT_CONTACT_DETAILS.email);
-        await addClubPage.fillInputField(addClubPage.clubWhatsUpField, NEW_CLUB_CORRECT_CONTACT_DETAILS.whatsup);
-        await addClubPage.fillInputField(addClubPage.clubWebPageField, NEW_CLUB_CORRECT_CONTACT_DETAILS.webPage);
-        
-        await addClubPage.proceedToNextStep();
+    await addClubPage.openAddLocationWindow();
+    await addClubPage.fillInputField(addClubPage.locationNameField, NEW_LOCATION_CORRECT_DETAILS.locationName);
+    await addClubPage.selectLocationCity(NEW_LOCATION_CORRECT_DETAILS.locationCity);
+    await addClubPage.selectLocationDistrict(NEW_LOCATION_CORRECT_DETAILS.locationDistrict);
+    await addClubPage.selectLocationStation(NEW_LOCATION_CORRECT_DETAILS.locationStation);
+    await addClubPage.fillInputField(addClubPage.locationAddressField, NEW_LOCATION_CORRECT_DETAILS.locationAddress);
+    await addClubPage.fillInputField(
+        addClubPage.locationCoordinatesField,
+        NEW_LOCATION_CORRECT_DETAILS.locationCoordinates
+    );
+    await addClubPage.fillInputField(addClubPage.locationPhoneNumberField, NEW_LOCATION_CORRECT_DETAILS.locationPhone);
+    await addClubPage.confirmLocationAddition();
 
-        await addClubPage.uploadLogo();
-        await addClubPage.uploadCover();
-        await addClubPage.uploadPhotoes();
+    await addClubPage.verifyLocationPresence(NEW_LOCATION_CORRECT_DETAILS.locationName);
 
-        await addClubPage.fillInputField(addClubPage.descriptionTextArea, NEW_CLUB_CORRECT_DETAILS.clubDescription);
-        await addClubPage.completeClubCreation();
+    await addClubPage.fillInputField(addClubPage.clubPhoneNumberField, NEW_CLUB_CORRECT_CONTACT_DETAILS.phoneNumber);
+    await addClubPage.fillInputField(addClubPage.clubFacebookField, NEW_CLUB_CORRECT_CONTACT_DETAILS.facebook);
+    await addClubPage.fillInputField(addClubPage.clubEmailField, NEW_CLUB_CORRECT_CONTACT_DETAILS.email);
+    await addClubPage.fillInputField(addClubPage.clubWhatsUpField, NEW_CLUB_CORRECT_CONTACT_DETAILS.whatsup);
+    await addClubPage.fillInputField(addClubPage.clubWebPageField, NEW_CLUB_CORRECT_CONTACT_DETAILS.webPage);
 
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.clubCreatedSuccessMessage, true, SUCCESS_CLUB_CREATION_MESSAGE);
-        
-        await userPage.gotoUserPage();
+    await addClubPage.proceedToNextStep();
 
-        // Verify that the created club information is correct
-        clubInfoPage = new ClubInfoPage(page);
-        await userPage.gotoUserPage();
-        await userPage.openClubInfoPage(NEW_CLUB_CORRECT_DETAILS.clubTitle);
-        await clubInfoPage.verifyElementVisibilityAndText(
-            clubInfoPage.clubPageTitle,
-            true,
-            NEW_CLUB_CORRECT_DETAILS.clubTitle
-        );
-        await clubInfoPage.expectElementToHaveText(clubInfoPage.clubPageTags, [
-            CLUB_CATEGORIES.acting,
-            CLUB_CATEGORIES.developmentCenter,
-            CLUB_CATEGORIES.programming,
-        ]);
-        await clubInfoPage.verifyElementVisibilityAndText(
-            clubInfoPage.clubPageAddress,
-            true,
-            NEW_LOCATION_CORRECT_DETAILS.locationAddress
-        );
-        await clubInfoPage.verifyElementVisibilityAndText(
-            clubInfoPage.clubPageDescription,
-            true,
-            NEW_CLUB_CORRECT_DETAILS.clubDescription
-        );
-        await clubInfoPage.expectElementToContainText(clubInfoPage.clubPageContactData, NEW_CLUB_CORRECT_CONTACT_DETAILS.email)
-        await clubInfoPage.expectElementToContainText(clubInfoPage.clubPageContactData, NEW_CLUB_CORRECT_CONTACT_DETAILS.facebook)
-        await clubInfoPage.expectElementToContainText(clubInfoPage.clubPageContactData, '+38'+NEW_CLUB_CORRECT_CONTACT_DETAILS.phoneNumber)
-        await clubInfoPage.expectElementToContainText(clubInfoPage.clubPageContactData, NEW_CLUB_CORRECT_CONTACT_DETAILS.whatsup)
-        await clubInfoPage.expectElementToContainText(clubInfoPage.clubPageContactData, NEW_CLUB_CORRECT_CONTACT_DETAILS.webPage)
-        
-        await clubInfoPage.verifyElementVisibilityAndText(
-            clubInfoPage.clubPageDevelopmentCenter,
-            true,
-            NEW_CLUB_CORRECT_DETAILS.clubRelatedCenter
-        );
-    });
+    await addClubPage.uploadLogo();
+    await addClubPage.uploadCover();
+    await addClubPage.uploadPhotoes();
+
+    await addClubPage.fillInputField(addClubPage.descriptionTextArea, NEW_CLUB_CORRECT_DETAILS.clubDescription);
+    await addClubPage.completeClubCreation();
+
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.clubCreatedSuccessMessage,
+        true,
+        SUCCESS_CLUB_CREATION_MESSAGE
+    );
+
+    await userPage.gotoUserPage();
+
+    // Verify that the created club information is correct
+    await userPage.gotoUserPage();
+    await userPage.openClubInfoPage(NEW_CLUB_CORRECT_DETAILS.clubTitle);
+    await clubInfoPage.verifyElementVisibilityAndText(
+        clubInfoPage.clubPageTitle,
+        true,
+        NEW_CLUB_CORRECT_DETAILS.clubTitle
+    );
+    await clubInfoPage.expectElementToHaveText(clubInfoPage.clubPageTags, [
+        CLUB_CATEGORIES.acting,
+        CLUB_CATEGORIES.developmentCenter,
+        CLUB_CATEGORIES.programming,
+    ]);
+    await clubInfoPage.verifyElementVisibilityAndText(
+        clubInfoPage.clubPageAddress,
+        true,
+        NEW_LOCATION_CORRECT_DETAILS.locationAddress
+    );
+    await clubInfoPage.verifyElementVisibilityAndText(
+        clubInfoPage.clubPageDescription,
+        true,
+        NEW_CLUB_CORRECT_DETAILS.clubDescription
+    );
+    await clubInfoPage.expectElementToContainText(
+        clubInfoPage.clubPageContactData,
+        NEW_CLUB_CORRECT_CONTACT_DETAILS.email
+    );
+    await clubInfoPage.expectElementToContainText(
+        clubInfoPage.clubPageContactData,
+        NEW_CLUB_CORRECT_CONTACT_DETAILS.facebook
+    );
+    await clubInfoPage.expectElementToContainText(
+        clubInfoPage.clubPageContactData,
+        NEW_CLUB_CORRECT_CONTACT_DETAILS.phoneNumber
+    );
+    await clubInfoPage.expectElementToContainText(
+        clubInfoPage.clubPageContactData,
+        NEW_CLUB_CORRECT_CONTACT_DETAILS.whatsup
+    );
+    await clubInfoPage.expectElementToContainText(
+        clubInfoPage.clubPageContactData,
+        NEW_CLUB_CORRECT_CONTACT_DETAILS.webPage
+    );
+    await clubInfoPage.verifyElementVisibilityAndText(
+        clubInfoPage.clubPageDevelopmentCenter,
+        true,
+        NEW_CLUB_CORRECT_DETAILS.clubRelatedCenter
+    );
+});
+
+test("Verify validation error messages appearence/disappearence on the first step", async () => {
+    await addClubPage.proceedToNextStep();
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.nameFieldErrorMessage,
+        true,
+        ADD_CLUB_VALIDATION_ERROR_MESSAGE.nameIsMandatory
+    );
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.categoryFieldErrorMessage,
+        true,
+        ADD_CLUB_VALIDATION_ERROR_MESSAGE.categoryIsMandatory
+    );
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.ageFromFieldErrorMessage,
+        true,
+        ADD_CLUB_VALIDATION_ERROR_MESSAGE.ageIsMandatory
+    );
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.ageToFieldErrorMessage,
+        true,
+        ADD_CLUB_VALIDATION_ERROR_MESSAGE.ageIsMandatory
+    );
+
+    await addClubPage.fillInputField(addClubPage.clubNameField, NEW_CLUB_INCORRECT_DETAILS.clubTitle);
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.nameFieldErrorMessage,
+        true,
+        ADD_CLUB_VALIDATION_ERROR_MESSAGE.nameIsIncorrect
+    );
+    await addClubPage.fillInputField(addClubPage.clubNameField, NEW_CLUB_CORRECT_DETAILS.clubTitle);
+    await addClubPage.verifyElementVisibilityAndText(addClubPage.nameFieldErrorMessage, false);
+
+    await addClubPage.toggleStatedCheckboxes(CLUB_CATEGORIES.acting);
+    await addClubPage.verifyElementVisibilityAndText(addClubPage.categoryFieldErrorMessage, false);
+
+    await addClubPage.setAcceptableChildAge(
+        NEW_CLUB_CORRECT_DETAILS.clubEnterAge,
+        NEW_CLUB_CORRECT_DETAILS.clubClosingAge
+    );
+    await addClubPage.verifyElementVisibilityAndText(addClubPage.ageFromFieldErrorMessage, false);
+    await addClubPage.verifyElementVisibilityAndText(addClubPage.ageFromFieldErrorMessage, false);
+});
+
+test("Verify validation error messages appearence/disappearence on the second step", async ({ page }) => {
+    await addClubPage.fillInputField(addClubPage.clubNameField, NEW_CLUB_CORRECT_DETAILS.clubTitle);
+    await addClubPage.toggleStatedCheckboxes(CLUB_CATEGORIES.acting);
+    await addClubPage.setAcceptableChildAge(
+        NEW_CLUB_CORRECT_DETAILS.clubEnterAge,
+        NEW_CLUB_CORRECT_DETAILS.clubClosingAge
+    );
+    await addClubPage.proceedToNextStep();
+    await addClubPage.openAddLocationWindow();
+
+    // Trigger validation of mandatory fields and verify that each is present and correct
+    await addClubPage.confirmLocationAddition();
+
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.locationNameFieldErrorMessage,
+        true,
+        ADD_LOCATION_VALIDATION_ERROR_MESSAGE.locationNameIsMandatory
+    );
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.locationCityErrorMessage,
+        true,
+        ADD_LOCATION_VALIDATION_ERROR_MESSAGE.cityIsMandatory
+    );
+
+    // This one is ommitted because of the defect which displays both mandatory and incorrect value validation for the address field
+    // await addclubpage.verifyElementVisibilityAndText(addclubpage.locationAddressFieldErrorMessage, true, ADD_LOCATION_VALIDATION_ERROR_MESSAGE.locationNameIsMandatory);
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.locationCoordinatesFieldErrorMessage,
+        true,
+        ADD_LOCATION_VALIDATION_ERROR_MESSAGE.coordinatesAreIncorrect
+    );
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.locationPhoneFieldErrorMessage,
+        true,
+        ADD_LOCATION_VALIDATION_ERROR_MESSAGE.phoneIsMandatory
+    );
+
+    // Fill fields with incorrect data and verify that appropriate error message appears
+    await addClubPage.fillInputField(addClubPage.locationNameField, NEW_LOCATION_INCORRECT_DETAILS.locationName);
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.locationNameFieldErrorMessage,
+        true,
+        ADD_LOCATION_VALIDATION_ERROR_MESSAGE.locationNameIsIncorrect
+    );
+
+    await addClubPage.fillInputField(addClubPage.locationAddressField, NEW_LOCATION_INCORRECT_DETAILS.locationAddress);
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.locationAddressFieldErrorMessage,
+        true,
+        ADD_LOCATION_VALIDATION_ERROR_MESSAGE.addressIsIncorrect
+    );
+
+    await addClubPage.fillInputField(
+        addClubPage.locationCoordinatesField,
+        NEW_LOCATION_INCORRECT_DETAILS.locationCoordinates
+    );
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.locationCoordinatesFieldErrorMessage,
+        true,
+        ADD_LOCATION_VALIDATION_ERROR_MESSAGE.coordinatesAreIncorrect
+    );
+    await addClubPage.fillInputField(
+        addClubPage.locationCoordinatesField,
+        NEW_LOCATION_INCORRECT_DETAILS.locationCoordinatesWithLetters
+    );
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.locationCoordinatesFieldErrorMessage,
+        true,
+        ADD_LOCATION_VALIDATION_ERROR_MESSAGE.coordinatesCantHaveLetters
+    );
+
+    await addClubPage.fillInputField(
+        addClubPage.locationPhoneNumberField,
+        NEW_LOCATION_INCORRECT_DETAILS.locationPhone
+    );
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.locationPhoneFieldErrorMessage,
+        true,
+        ADD_LOCATION_VALIDATION_ERROR_MESSAGE.phoneIsIncorrect
+    );
+
+    // Fill fields with correct data and verify that error messages disappear
+    await addClubPage.fillInputField(addClubPage.locationNameField, NEW_LOCATION_CORRECT_DETAILS.locationName);
+    await addClubPage.verifyElementVisibilityAndText(addClubPage.locationNameFieldErrorMessage, false);
+
+    await addClubPage.selectLocationCity(NEW_LOCATION_CORRECT_DETAILS.locationCity);
+    await addClubPage.verifyElementVisibilityAndText(addClubPage.locationCityErrorMessage, false);
+
+    await addClubPage.fillInputField(addClubPage.locationAddressField, NEW_LOCATION_CORRECT_DETAILS.locationAddress);
+    await addClubPage.verifyElementVisibilityAndText(addClubPage.locationCityErrorMessage, false);
+
+    await addClubPage.fillInputField(
+        addClubPage.locationCoordinatesField,
+        NEW_LOCATION_CORRECT_DETAILS.locationCoordinates
+    );
+    await addClubPage.verifyElementVisibilityAndText(addClubPage.locationCoordinatesFieldErrorMessage, false);
+
+    await addClubPage.fillInputField(addClubPage.locationPhoneNumberField, NEW_LOCATION_CORRECT_DETAILS.locationPhone);
+    await addClubPage.verifyElementVisibilityAndText(addClubPage.locationPhoneFieldErrorMessage, false);
+
+    await addClubPage.confirmLocationAddition();
+
+    // Trigger step 2 mandatory fields validation
+    await addClubPage.proceedToNextStep();
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.clubPhoneFieldErrorMessage,
+        true,
+        ADD_CLUB_VALIDATION_ERROR_MESSAGE.phoneIsMandatory
+    );
+
+    await addClubPage.fillInputField(
+        addClubPage.clubPhoneNumberField,
+        NEW_CLUB_INCORRECT_CONTACT_DETAILS.phoneNumberIncorrectFormat
+    );
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.clubPhoneFieldErrorMessage,
+        true,
+        ADD_CLUB_VALIDATION_ERROR_MESSAGE.phoneIsIncorrect
+    );
+    await addClubPage.fillInputField(
+        addClubPage.clubPhoneNumberField,
+        NEW_CLUB_INCORRECT_CONTACT_DETAILS.phoneNumberIncorrectFormatWithLetters
+    );
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.clubPhoneFieldErrorMessage,
+        true,
+        ADD_CLUB_VALIDATION_ERROR_MESSAGE.phoneIsIncorrectCantHaveLetters
+    );
+    await addClubPage.fillInputField(addClubPage.clubPhoneNumberField, NEW_CLUB_CORRECT_CONTACT_DETAILS.phoneNumber);
+    await addClubPage.verifyElementVisibilityAndText(addClubPage.clubPhoneFieldErrorMessage, false);
+
+    await addClubPage.fillInputField(addClubPage.clubEmailField, NEW_CLUB_INCORRECT_CONTACT_DETAILS.email);
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.clubEmailFieldErrorMessage,
+        true,
+        ADD_CLUB_VALIDATION_ERROR_MESSAGE.emailIsIncorrect
+    );
+    await addClubPage.fillInputField(addClubPage.clubEmailField, NEW_CLUB_CORRECT_CONTACT_DETAILS.email);
+    await addClubPage.verifyElementVisibilityAndText(addClubPage.clubEmailFieldErrorMessage, false);
+});
+
+test("Verify validation error messages appearence/disappearence on the third step", async ({ page }) => {
+    await addClubPage.fillInputField(addClubPage.clubNameField, NEW_CLUB_CORRECT_DETAILS.clubTitle);
+    await addClubPage.toggleStatedCheckboxes(CLUB_CATEGORIES.acting);
+    await addClubPage.setAcceptableChildAge(
+        NEW_CLUB_CORRECT_DETAILS.clubEnterAge,
+        NEW_CLUB_CORRECT_DETAILS.clubClosingAge
+    );
+    await addClubPage.proceedToNextStep();
+    await addClubPage.fillInputField(addClubPage.clubPhoneNumberField, NEW_CLUB_CORRECT_CONTACT_DETAILS.phoneNumber);
+    await addClubPage.proceedToNextStep();
+
+    await addClubPage.completeClubCreation();
     
+    // To be updated once the correct error messages are implemented
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.clubDescriptionErrorMessage,
+        true,
+        ADD_CLUB_VALIDATION_ERROR_MESSAGE.descriptionIsIncorrect
+    );
+    await addClubPage.fillInputField(addClubPage.descriptionTextArea, NEW_CLUB_INCORRECT_DETAILS.clubDescription);
+    await addClubPage.verifyElementVisibilityAndText(
+        addClubPage.clubDescriptionErrorMessage,
+        true,
+        ADD_CLUB_VALIDATION_ERROR_MESSAGE.descriptionIsIncorrectCharLimit
+    );
+    await addClubPage.fillInputField(addClubPage.descriptionTextArea, NEW_CLUB_CORRECT_DETAILS.clubDescription);
+    await addClubPage.verifyElementVisibilityAndText(addClubPage.clubDescriptionErrorMessage, false);
+});
 
-    test("Verify validation error messages appearence/disappearence on the first step", async ({ page }) => {
-        await addClubPage.proceedToNextStep();
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.nameFieldErrorMessage, true, ADD_CLUB_VALIDATION_ERROR_MESSAGE.nameIsMandatory);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.categoryFieldErrorMessage, true,ADD_CLUB_VALIDATION_ERROR_MESSAGE.categoryIsMandatory);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.ageFromFieldErrorMessage, true,ADD_CLUB_VALIDATION_ERROR_MESSAGE.ageIsMandatory);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.ageToFieldErrorMessage, true,ADD_CLUB_VALIDATION_ERROR_MESSAGE.ageIsMandatory);
+test("Verify that tooltips and warning messages appear", async () => {
+    // Remove the club with the test club_title if it exists
+    await apiService.createNewClub(CREATE_CLUB_REQUEST);
+    await addClubPage.fillInputField(addClubPage.clubNameField, CREATE_CLUB_REQUEST.body.name);
+    await addClubPage.toggleStatedCheckboxes(CLUB_CATEGORIES.acting);
+    await addClubPage.setAcceptableChildAge(
+        NEW_CLUB_CORRECT_DETAILS.clubEnterAge,
+        NEW_CLUB_CORRECT_DETAILS.clubClosingAge
+    );
+    await addClubPage.proceedToNextStep();
+    await addClubPage.openAddLocationWindow();
 
-        await addClubPage.fillInputField(addClubPage.clubNameField, NEW_CLUB_INCORRECT_DETAILS.clubTitle);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.nameFieldErrorMessage, true, ADD_CLUB_VALIDATION_ERROR_MESSAGE.nameIsIncorrect);
-        await addClubPage.fillInputField(addClubPage.clubNameField, NEW_CLUB_CORRECT_DETAILS.clubTitle);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.nameFieldErrorMessage, false);
+    await addClubPage.verifyLocationNameTooltipAppearsOnHover();
+    await addClubPage.verifyLocationPhoneTooltipAppearsOnHover();
+    await addClubPage.closeAddLocationWindow();
 
-        await addClubPage.toggleStatedCheckboxes(CLUB_CATEGORIES.acting);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.categoryFieldErrorMessage, false);
+    await addClubPage.verifyAvailableOnlineTooltipAppearsOnHover();
 
-        await addClubPage.setAcceptableChildAge(
-            NEW_CLUB_CORRECT_DETAILS.clubEnterAge,
-            NEW_CLUB_CORRECT_DETAILS.clubClosingAge
-        );
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.ageFromFieldErrorMessage, false);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.ageFromFieldErrorMessage, false);
-    });
+    await addClubPage.fillInputField(addClubPage.clubPhoneNumberField, NEW_CLUB_CORRECT_CONTACT_DETAILS.phoneNumber);
+    await addClubPage.proceedToNextStep();
 
-    test("Verify validation error messages appearence/disappearence on the second step", async ({ page }) => {
-        await addClubPage.fillInputField(addClubPage.clubNameField, NEW_CLUB_CORRECT_DETAILS.clubTitle);
-        await addClubPage.toggleStatedCheckboxes(
-            CLUB_CATEGORIES.acting,
-        );
-        await addClubPage.setAcceptableChildAge(NEW_CLUB_CORRECT_DETAILS.clubEnterAge, NEW_CLUB_CORRECT_DETAILS.clubClosingAge);
-        await addClubPage.proceedToNextStep();
-        await addClubPage.openAddLocationWindow();
+    await addClubPage.verifyElementVisibility(addClubPage.clubIsAutomaticallyOnlineMessage, true);
+    await addClubPage.fillInputField(addClubPage.descriptionTextArea, NEW_CLUB_CORRECT_DETAILS.clubDescription);
+    await addClubPage.completeClubCreation();
+    await addClubPage.verifyElementVisibility(addClubPage.clubAlreadyExistMessage, true);
+});
 
-        // Trigger validation of mandatory fields and verify that each is present and correct
-        await addClubPage.confirmLocationAddition();
-        
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationNameFieldErrorMessage, true, ADD_LOCATION_VALIDATION_ERROR_MESSAGE.locationNameIsMandatory);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationCityErrorMessage, true, ADD_LOCATION_VALIDATION_ERROR_MESSAGE.cityIsMandatory);
-
-        // This one is ommitted because of the defect which displays both mandatory and incorrect value validation for the address field
-        // await addclubpage.verifyElementVisibilityAndText(addclubpage.locationAddressFieldErrorMessage, true, ADD_LOCATION_VALIDATION_ERROR_MESSAGE.locationNameIsMandatory);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationCoordinatesFieldErrorMessage, true, ADD_LOCATION_VALIDATION_ERROR_MESSAGE.coordinatesAreIncorrect);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationPhoneFieldErrorMessage, true, ADD_LOCATION_VALIDATION_ERROR_MESSAGE.phoneIsMandatory);
-
-        // Fill fields with incorrect data and verify that appropriate error message appears
-        await addClubPage.fillInputField(addClubPage.locationNameField, NEW_LOCATION_INCORRECT_DETAILS.locationName);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationNameFieldErrorMessage, true, ADD_LOCATION_VALIDATION_ERROR_MESSAGE.locationNameIsIncorrect);
-
-        await addClubPage.fillInputField(addClubPage.locationAddressField, NEW_LOCATION_INCORRECT_DETAILS.locationAddress);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationAddressFieldErrorMessage, true, ADD_LOCATION_VALIDATION_ERROR_MESSAGE.addressIsIncorrect);
-
-        await addClubPage.fillInputField(addClubPage.locationCoordinatesField, NEW_LOCATION_INCORRECT_DETAILS.locationCoordinates);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationCoordinatesFieldErrorMessage, true, ADD_LOCATION_VALIDATION_ERROR_MESSAGE.coordinatesAreIncorrect);
-        await addClubPage.fillInputField(addClubPage.locationCoordinatesField, NEW_LOCATION_INCORRECT_DETAILS.locationCoordinatesWithLetters);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationCoordinatesFieldErrorMessage, true, ADD_LOCATION_VALIDATION_ERROR_MESSAGE.coordinatesCantHaveLetters);
-
-        await addClubPage.fillInputField(addClubPage.locationPhoneNumberField, NEW_LOCATION_INCORRECT_DETAILS.locationPhone);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationPhoneFieldErrorMessage, true, ADD_LOCATION_VALIDATION_ERROR_MESSAGE.phoneIsIncorrect);
-
-        // Fill fields with correct data and verify that error messages disappear
-        await addClubPage.fillInputField(addClubPage.locationNameField, NEW_LOCATION_CORRECT_DETAILS.locationName);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationNameFieldErrorMessage, false);
-
-        await addClubPage.selectLocationCity(NEW_LOCATION_CORRECT_DETAILS.locationCity);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationCityErrorMessage, false);
-
-        await addClubPage.fillInputField(addClubPage.locationAddressField, NEW_LOCATION_CORRECT_DETAILS.locationAddress);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationCityErrorMessage, false);
-
-        await addClubPage.fillInputField(addClubPage.locationCoordinatesField, NEW_LOCATION_CORRECT_DETAILS.locationCoordinates);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationCoordinatesFieldErrorMessage, false);
-
-        await addClubPage.fillInputField(addClubPage.locationPhoneNumberField, NEW_LOCATION_CORRECT_DETAILS.locationPhone);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.locationPhoneFieldErrorMessage, false);
-
-        await addClubPage.confirmLocationAddition();
-
-        // Trigger step 2 mandatory fields validation
-        await addClubPage.proceedToNextStep();
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.clubPhoneFieldErrorMessage, true, ADD_CLUB_VALIDATION_ERROR_MESSAGE.phoneIsMandatory);
-
-        await addClubPage.fillInputField(addClubPage.clubPhoneNumberField, NEW_CLUB_INCORRECT_CONTACT_DETAILS.phoneNumberIncorrectFormat);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.clubPhoneFieldErrorMessage, true, ADD_CLUB_VALIDATION_ERROR_MESSAGE.phoneIsIncorrect);
-        await addClubPage.fillInputField(addClubPage.clubPhoneNumberField, NEW_CLUB_INCORRECT_CONTACT_DETAILS.phoneNumberIncorrectFormatWithLetters);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.clubPhoneFieldErrorMessage, true, ADD_CLUB_VALIDATION_ERROR_MESSAGE.phoneIsIncorrectCantHaveLetters);
-        await addClubPage.fillInputField(addClubPage.clubPhoneNumberField, NEW_CLUB_CORRECT_CONTACT_DETAILS.phoneNumber);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.clubPhoneFieldErrorMessage, false);
-
-        await addClubPage.fillInputField(addClubPage.clubEmailField, NEW_CLUB_INCORRECT_CONTACT_DETAILS.email);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.clubEmailFieldErrorMessage, true, ADD_CLUB_VALIDATION_ERROR_MESSAGE.emailIsIncorrect); 
-        await addClubPage.fillInputField(addClubPage.clubEmailField, NEW_CLUB_CORRECT_CONTACT_DETAILS.email);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.clubEmailFieldErrorMessage, false); 
-    });
-
-
-    test("Verify validation error messages appearence/disappearence on the third step", async ({ page }) => {
-        await addClubPage.fillInputField(addClubPage.clubNameField, NEW_CLUB_CORRECT_DETAILS.clubTitle);
-        await addClubPage.toggleStatedCheckboxes(
-            CLUB_CATEGORIES.acting,
-        );
-        await addClubPage.setAcceptableChildAge(NEW_CLUB_CORRECT_DETAILS.clubEnterAge, NEW_CLUB_CORRECT_DETAILS.clubClosingAge);
-        await addClubPage.proceedToNextStep();
-        await addClubPage.fillInputField(addClubPage.clubPhoneNumberField, NEW_CLUB_CORRECT_CONTACT_DETAILS.phoneNumber);
-        await addClubPage.proceedToNextStep();
-
-        await addClubPage.completeClubCreation();
-        // To be updated once the correct error messages are implemented
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.clubDescriptionErrorMessage, true, ADD_CLUB_VALIDATION_ERROR_MESSAGE.descriptionIsIncorrect); 
-        await addClubPage.fillInputField(addClubPage.descriptionTextArea, NEW_CLUB_INCORRECT_DETAILS.clubDescription);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.clubDescriptionErrorMessage, true, ADD_CLUB_VALIDATION_ERROR_MESSAGE.descriptionIsIncorrectCharLimit); 
-        await addClubPage.fillInputField(addClubPage.descriptionTextArea, NEW_CLUB_CORRECT_DETAILS.clubDescription);
-        await addClubPage.verifyElementVisibilityAndText(addClubPage.clubDescriptionErrorMessage, false); 
-
-    });
-
-
-    test("Verify that tooltips and warning messages appear", async ({ page }) => {
-        // Remove the club with the test club_title if it exists
-        try {
-            await apiService.deleteClubByTitle(NEW_CLUB_CORRECT_DETAILS.clubTitle);
-        } catch (e) {
-            console.error(e);
-        }
-
-        await addClubPage.fillInputField(addClubPage.clubNameField, NEW_CLUB_CORRECT_DETAILS.clubTitle);
-        await addClubPage.toggleStatedCheckboxes(CLUB_CATEGORIES.acting);
-        await addClubPage.setAcceptableChildAge(
-            NEW_CLUB_CORRECT_DETAILS.clubEnterAge,
-            NEW_CLUB_CORRECT_DETAILS.clubClosingAge
-        );
-        await addClubPage.proceedToNextStep();
-        await addClubPage.openAddLocationWindow();
-
-        await addClubPage.verifyLocationNameTooltipAppearsOnHover();
-        await addClubPage.verifyLocationPhoneTooltipAppearsOnHover();
-        await addClubPage.closeAddLocationWindow();
-
-        await addClubPage.verifyAvailableOnlineTooltipAppearsOnHover();
-
-        await addClubPage.fillInputField(addClubPage.clubPhoneNumberField, NEW_CLUB_CORRECT_CONTACT_DETAILS.phoneNumber);
-        await addClubPage.proceedToNextStep();
-
-        await addClubPage.verifyElementVisibility(addClubPage.clubIsAutomaticallyOnlineMessage, true);
-        await addClubPage.fillInputField(addClubPage.descriptionTextArea, NEW_CLUB_CORRECT_DETAILS.clubDescription);
-
-        /* 
-         * Complete club creation and go through the creation steps again to verify that
-         * 'this club already exists' message appears
-         */
-        await addClubPage.completeClubCreation();
-        await homePage.openAddClubPage();
-        await addClubPage.fillInputField(addClubPage.clubNameField, NEW_CLUB_CORRECT_DETAILS.clubTitle);
-        await addClubPage.toggleStatedCheckboxes(CLUB_CATEGORIES.acting);
-        await addClubPage.setAcceptableChildAge(
-            NEW_CLUB_CORRECT_DETAILS.clubEnterAge,
-            NEW_CLUB_CORRECT_DETAILS.clubClosingAge
-        );
-        await addClubPage.proceedToNextStep();
-        await addClubPage.fillInputField(addClubPage.clubPhoneNumberField, NEW_CLUB_CORRECT_CONTACT_DETAILS.phoneNumber);
-        await addClubPage.proceedToNextStep();
-        await addClubPage.fillInputField(addClubPage.descriptionTextArea, NEW_CLUB_CORRECT_DETAILS.clubDescription);
-
-        await addClubPage.completeClubCreation();
-        await addClubPage.verifyElementVisibility(addClubPage.clubAlreadyExistMessage, true);
-    });
-
-    test.afterEach(async ({ page }) => {
-        await page.close();
-    });
+test.afterAll(async () => {
+    await page.close();
+});


### PR DESCRIPTION
In this pull request, I've made the following improvements:

Refactor the addClub-test.spec to improve readability and execution speed.

Added a new CREATE_CLUB_REQUEST_2 to make addClub-test & editClub-test able to make both tests independent.

Improved beforeEach/All hook logic.

Parametrized createNewClub() method in the ApiService.js